### PR TITLE
Improve Publish efficiency by avoid allocations.

### DIFF
--- a/src/client/value_types.rs
+++ b/src/client/value_types.rs
@@ -1,27 +1,197 @@
 use crate::Result;
-use mqttrs::{
-    QoS,
-    SubscribeReturnCodes,
-    SubscribeTopic,
-};
+use mqttrs::{QoS, SubscribeReturnCodes, SubscribeTopic};
+use std::borrow::Cow;
 use tokio::time::Duration;
+
+const BUF_SIZE: usize = 8;
+
+/// A publish payload.
+#[derive(Clone, Debug)]
+pub enum Payload {
+    Fixed([u8; BUF_SIZE], u8),
+    Variable(Vec<u8>),
+}
+
+impl From<Vec<u8>> for Payload {
+    fn from(data: Vec<u8>) -> Self {
+        Self::Variable(data)
+    }
+}
+impl From<&[u8; 1]> for Payload {
+    fn from(data: &[u8; 1]) -> Self {
+        Self::Fixed([data[0]; BUF_SIZE], 1)
+    }
+}
+impl From<[u8; 1]> for Payload {
+    fn from(data: [u8; 1]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 2]> for Payload {
+    fn from(data: &[u8; 2]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 2]> for Payload {
+    fn from(data: [u8; 2]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 3]> for Payload {
+    fn from(data: &[u8; 3]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 3]> for Payload {
+    fn from(data: [u8; 3]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 4]> for Payload {
+    fn from(data: &[u8; 4]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 4]> for Payload {
+    fn from(data: [u8; 4]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 5]> for Payload {
+    fn from(data: &[u8; 5]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 5]> for Payload {
+    fn from(data: [u8; 5]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 6]> for Payload {
+    fn from(data: &[u8; 6]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 6]> for Payload {
+    fn from(data: [u8; 6]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 7]> for Payload {
+    fn from(data: &[u8; 7]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 7]> for Payload {
+    fn from(data: [u8; 7]) -> Self {
+        (&data).into()
+    }
+}
+impl From<&[u8; 8]> for Payload {
+    fn from(data: &[u8; 8]) -> Self {
+        let mut buf = [0_u8; BUF_SIZE];
+        buf[..data.len()].copy_from_slice(data);
+        Self::Fixed(buf, data.len() as u8)
+    }
+}
+impl From<[u8; 8]> for Payload {
+    fn from(data: [u8; 8]) -> Self {
+        (&data).into()
+    }
+}
+
+impl From<u8> for Payload {
+    fn from(data: u8) -> Self {
+        [data; 1].into()
+    }
+}
+impl From<i8> for Payload {
+    fn from(data: i8) -> Self {
+        [data as u8; 1].into()
+    }
+}
+impl From<u16> for Payload {
+    fn from(data: u16) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<i16> for Payload {
+    fn from(data: i16) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<u32> for Payload {
+    fn from(data: u32) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<i32> for Payload {
+    fn from(data: i32) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<u64> for Payload {
+    fn from(data: u64) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<i64> for Payload {
+    fn from(data: i64) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<f32> for Payload {
+    fn from(data: f32) -> Self {
+        data.to_le_bytes().into()
+    }
+}
+impl From<f64> for Payload {
+    fn from(data: f64) -> Self {
+        data.to_le_bytes().into()
+    }
+}
 
 /// Arguments for a publish operation.
 #[derive(Clone, Debug)]
 pub struct Publish {
-    topic: String,
-    payload: Vec<u8>,
+    topic: Cow<'static, str>,
+    payload: Payload,
     qos: QoS,
     retain: bool,
 }
 
 impl Publish {
     /// Construct a new instance.
-    pub fn new(topic: String, payload: Vec<u8>) -> Publish {
+    pub fn new<T, V>(topic: T, payload: V) -> Publish
+    where
+        T: Into<Cow<'static, str>>,
+        V: Into<Payload>,
+    {
+        Publish::new_with_qos(topic, payload, QoS::AtMostOnce)
+    }
+
+    /// Construct a new instance with QoS.
+    pub fn new_with_qos<T, V>(topic: T, payload: V, qos: QoS) -> Publish
+    where
+        T: Into<Cow<'static, str>>,
+        V: Into<Payload>,
+    {
         Publish {
-            topic,
-            payload,
-            qos: QoS::AtMostOnce,
+            topic: topic.into(),
+            payload: payload.into(),
+            qos: qos,
             retain: false,
         }
     }
@@ -33,7 +203,10 @@ impl Publish {
 
     /// Returns the payload data of this instance.
     pub fn payload(&self) -> &[u8] {
-        &*self.payload
+        match self.payload {
+            Payload::Fixed(ref buf, len) => &buf[..(len as usize)],
+            Payload::Variable(ref buf) => buf,
+        }
     }
 
     /// Returns the QoS level configured.
@@ -74,9 +247,7 @@ pub struct Subscribe {
 impl Subscribe {
     /// Construct a new instance.
     pub fn new(v: Vec<SubscribeTopic>) -> Subscribe {
-        Subscribe {
-            topics: v,
-        }
+        Subscribe { topics: v }
     }
 
     /// Returns the topics selected.
@@ -99,9 +270,10 @@ impl SubscribeResult {
 
     /// Returns an error if any return codes from the operation were `Failure`.
     pub fn any_failures(&self) -> Result<()> {
-        let any_failed =
-            self.return_codes().iter()
-                .any(|rc| *rc == SubscribeReturnCodes::Failure);
+        let any_failed = self
+            .return_codes()
+            .iter()
+            .any(|rc| *rc == SubscribeReturnCodes::Failure);
         if any_failed {
             return Err(format!("Some subscribes failed: {:#?}", self.return_codes()).into());
         }
@@ -111,7 +283,7 @@ impl SubscribeResult {
 
 /// Arguments for an unsubscribe operation.
 pub struct Unsubscribe {
-    topics: Vec<UnsubscribeTopic>
+    topics: Vec<UnsubscribeTopic>,
 }
 
 impl Unsubscribe {
@@ -134,7 +306,9 @@ pub struct UnsubscribeTopic {
 impl UnsubscribeTopic {
     /// Construct a new instance.
     pub fn new(topic_name: String) -> UnsubscribeTopic {
-        UnsubscribeTopic { topic_name: topic_name }
+        UnsubscribeTopic {
+            topic_name: topic_name,
+        }
     }
 
     /// Returns the topic name for the operation.
@@ -171,7 +345,7 @@ pub enum KeepAlive {
     /// Send a keep alive ping packet every `secs` seconds.
     Enabled {
         /// The number of seconds between packets.
-        secs: u16
+        secs: u16,
     },
 }
 
@@ -183,7 +357,7 @@ impl KeepAlive {
         if secs == 0 {
             panic!("KeepAlive secs == 0 not permitted");
         }
-        KeepAlive::Enabled { secs, }
+        KeepAlive::Enabled { secs }
     }
 
     /// Disable keep alive functionality.
@@ -212,9 +386,7 @@ impl KeepAlive {
     pub fn as_duration(&self) -> Option<Duration> {
         match self {
             KeepAlive::Disabled => None,
-            KeepAlive::Enabled { secs } => {
-                Some(Duration::from_secs(*secs as u64))
-            },
+            KeepAlive::Enabled { secs } => Some(Duration::from_secs(*secs as u64)),
         }
     }
 }


### PR DESCRIPTION
Changes:

- Abstract out `Payload` with a minimum fixed buffer of 8 bytes.  Anything larger goes into a `Vec<u8>`.
- Standard conversions of standard types to `Payload`.
- Use `Cow<'static, str>` for `Publish` topic to enable using constant strings as topics.

Sorry, since you don't have a `rustfmt.toml`, it messes up your formatting a bit.
