### PR TITLE
Shutdown connection when socket gets disconnected.

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -3,6 +3,7 @@ use crate::{
         Client,
         ClientOptions,
         client::ConnectionMode,
+        value_types::Publish,
         KeepAlive,
     },
     Error, Result,
@@ -12,6 +13,7 @@ use crate::{
 };
 
 use url::Url;
+use Publish as LastWill;
 
 #[cfg(any(feature = "tls", feature = "websocket"))]
 use ::rustls;
@@ -37,6 +39,7 @@ pub struct ClientBuilder {
     connection_mode: ConnectionMode,
     automatic_connect: Option<bool>,
     connect_retry_delay: Option<Duration>,
+    last_will: Option<LastWill>,
 }
 
 impl ClientBuilder {
@@ -58,6 +61,7 @@ impl ClientBuilder {
             connection_mode: self.connection_mode.clone(),
             automatic_connect: self.automatic_connect.unwrap_or(true),
             connect_retry_delay: self.connect_retry_delay.unwrap_or(Duration::from_secs(30)),
+            last_will: self.last_will.clone(),
         })
     }
 
@@ -102,6 +106,14 @@ impl ClientBuilder {
         };
         self.url = Some(url);
         Ok(self)
+    }
+
+    /// Set the last will testament topic
+    ///
+    /// Topic published by broker as connection to (this) client is lost
+    pub fn set_last_will(&mut self, lwt: &LastWill) -> &mut Self {
+        self.last_will = Some(lwt.to_owned());
+        self
     }
 
     /// Set username to authenticate with.

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -916,6 +916,8 @@ impl IoTask {
 
         match read {
             Err(Error::Disconnected) => {
+                // Drop Connection as socket disconnected itself
+                self.shutdown_conn().await;
                 self.tx_recv_published.send(Err(Error::Disconnected)).await
                     .map_err(Error::from_std_err)?;
             }


### PR DESCRIPTION
Some words on my motivation for this PR: 

While using the TLS transport I found the library to continuously print the error: "IoTask: Socket disconnected" in my logs. The only location of the print is read_packet(). I did some code review and this to be reason: 

When in connected state, the return handler is handle_read() (via  run_once_connected()). handle_read() sends the disconnected error into the RX channel but does not shutdown the connection in the IoTask. As sending the Error into the channel is successfully the handler also returns successfully and run_once_connected() is called again and again, leading always to the same disconnected error.

Unfortunately I was not able to find a way to reproduce this behavior in my setup. As the broker for me runs in some infrastructure I was not able to kill the broker for creating a situation leaving a dangling socket behind. I expect the behavior to be reproducible easily by just killing the broker and waiting until the socket gets closed by the kernel. 

Even that I did not test, I think closing the connection as the socket reports itself as disconnect is a missing action in the I/O-Task. Independent whether the socket can be closed successfully or not by shutdown_conn(), at the end the connection state will be set to disconnected and resources should have been released. So the maximum pain to happen will be a second error printed. But 2 error prints is much less pain compared to having one error printed again and again until the user drops the connection.

In the mqttc example, there is actually a handler for the disconnected state. So this error will never be observed, however there should be possible more than a single disconnected error printed.

if the patch is wrong as the lib user is expected to handle the disconnected error, this perhaps should be mentioned explicitly in the documentation. In this case, I think there should be some hints on how this is intended to be handled by the user in the right way, too. 

Sorry for not verifying this patch. If you are really unhappy with me, let me know and I will try to setup the test environment on my private HW. Perhaps you can give things a try on your environment which for sure will be ready to be used.