### PR TITLE
Add support for draining publish events before shutting down.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 description = "An MQTT 3.1.1 client written in Rust, using async functions and tokio."
 repository = "https://github.com/fluffysquirrels/mqtt-async-client-rs"
 
+[[example]]
+name = "mqttc"
+
 [dependencies]
 bytes = "0.4.0"
 futures-core = "0.3.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// The client is disconnected.
     Disconnected,
+    /// The client read zero bytes from the stream.
+    ZeroRead,
 
     /// An error represented by an implementation of std::error::Error.
     StdError(Box<dyn std::error::Error + Send + Sync>),
@@ -33,6 +35,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> std::result::Result<(), fmt::Error> {
         match self {
             Error::Disconnected => write!(f, "Disconnected"),
+            Error::ZeroRead => write!(f, "ZeroRead"),
             Error::StdError(e) => write!(f, "{}", e),
             Error::String(s) => write!(f, "{}", s),
             Error::_NonExhaustive => panic!("Not reachable"),


### PR DESCRIPTION
This change does two things:

1. Adds logic to drain `rx_io_requests` on shutdown, this ensures that all outgoing requests to the MQTT broken are processed by the IoTask before the task is shutdown.
2. Changes the behavior of a zero read from the client. A zero read does not indicate a disconnect from the broker and so this change simply ignores zero reads and continues processing. 

I have been using these changes locally for a few weeks without issue now.

